### PR TITLE
Enable react hook plugin rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,8 @@ module.exports = {
     "import/no-named-as-default": 0,
     "@typescript-eslint/no-inferrable-types": 0,
     "import/no-duplicates": 0,
-    "import/named": 0
+    "import/named": 0,
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
   }
 };


### PR DESCRIPTION
We need to enable these rules in order to utilize the plugin we've included. Without it, we have no linting over hooks implementation. Tested on GeCom